### PR TITLE
Replaced deprecated dependency on luacrypto by the actual library luaossl

### DIFF
--- a/luajwtjitsi-1.3-7.rockspec
+++ b/luajwtjitsi-1.3-7.rockspec
@@ -15,7 +15,7 @@ description = {
 
 dependencies = {
 	"lua >= 5.1",
-	"luacrypto >= 0.3.2-1",
+	"luaossl >= 20190731-0",
 	"lua-cjson >= 2.1.0",
 	"lbase64 >= 20120807-3"
 }
@@ -26,3 +26,4 @@ build = {
 		luajwtjitsi = "luajwtjitsi.lua"
 	}
 }
+

--- a/luajwtjitsi.lua
+++ b/luajwtjitsi.lua
@@ -1,29 +1,31 @@
 local cjson  = require 'cjson'
 local base64 = require 'base64'
-local crypto = require 'crypto'
+local hmac = require 'openssl.hmac'
+local pkey = require 'openssl.pkey'
+local digest = require 'openssl.digest'
 
 local function signRS (data, key, algo)
-	local privkey = crypto.pkey.from_pem(key, true)
+	local privkey = pkey.new(key, "PEM")
 	if privkey == nil then
 		return nil, 'Not a private PEM key'
 	else
-		return crypto.sign(algo, data, privkey)
+		return privkey:sign(digest.new(key, algo):update(data))
 	end
 end
 
 local function verifyRS (data, signature, key, algo)
-	local pubkey = crypto.pkey.from_pem(key)
+	local pubkey = pkey.new(key, "PEM")
 	if pubkey == nil then
 		return nil, 'Not a public PEM key'
 	else
-		return crypto.verify(algo, data, signature, pubkey)
+		return pubkey:verify(signature, digest.new(key, algo):update(data))
 	end
 end
 
 local alg_sign = {
-	['HS256'] = function(data, key) return crypto.hmac.digest('sha256', data, key, true) end,
-	['HS384'] = function(data, key) return crypto.hmac.digest('sha384', data, key, true) end,
-	['HS512'] = function(data, key) return crypto.hmac.digest('sha512', data, key, true) end,
+	['HS256'] = function(data, key) return hmac.new(key, "sha256"):final(data) end,
+	['HS384'] = function(data, key) return hmac.new(key, "sha384"):final(data) end,
+	['HS512'] = function(data, key) return hmac.new(key, "sha512"):final(data) end,
 	['RS256'] = function(data, key) return signRS(data, key, 'sha256') end,
 	['RS384'] = function(data, key) return signRS(data, key, 'sha384') end,
 	['RS512'] = function(data, key) return signRS(data, key, 'sha512') end


### PR DESCRIPTION
Hi. This is important because luacrypto is deprecated and builds only with libssl1.0-dev but not with 1.1. So, this will fix issues like https://community.jitsi.org/t/solved-error-installing-jitsi-token-will-it-work-this-way/17142 in that cases when installation of the old version libssl1.0-dev is undesirable.