### PR TITLE
Use luaossl instead of luacrypto

### DIFF
--- a/luajwtjitsi-1.3-7.rockspec
+++ b/luajwtjitsi-1.3-7.rockspec
@@ -1,9 +1,9 @@
 package = "luajwtjitsi"
-version = "1.3-7"
+version = "1.3-8"
 
 source = {
 	url = "git://github.com/jitsi/luajwt/",
-	tag = "v1.7"
+	tag = "v1.8"
 }
 
 description = {
@@ -15,8 +15,8 @@ description = {
 
 dependencies = {
 	"lua >= 5.1",
-	"luacrypto >= 0.3.2-1",
-	"lua-cjson >= 2.1.0",
+	"luaossl >= 20151221-0",
+	"lua-cjson-ol >= 1.0-1",
 	"lbase64 >= 20120807-3"
 }
 

--- a/luajwtjitsi.lua
+++ b/luajwtjitsi.lua
@@ -17,9 +17,9 @@ local function signHS(data, key, algo)
 end
 
 local alg_sign = {
-	['HS256'] = function(data, key) return hmac_digest(data, key, 'sha256') end,
-	['HS384'] = function(data, key) return hmac_digest(data, key, 'sha384') end,
-	['HS512'] = function(data, key) return hmac_digest(data, key, 'sha512') end,
+	['HS256'] = function(data, key) return signHS(data, key, 'sha256') end,
+	['HS384'] = function(data, key) return signHS(data, key, 'sha384') end,
+	['HS512'] = function(data, key) return signHS(data, key, 'sha512') end,
 	['RS256'] = function(data, key) return signRS(data, key, 'sha256') end,
 	['RS384'] = function(data, key) return signRS(data, key, 'sha384') end,
 	['RS512'] = function(data, key) return signRS(data, key, 'sha512') end


### PR DESCRIPTION
LuaCrypto is very difficult to install on modern releases of Ubuntu (and likely other OSes) due to it being incompatible with newer libopenssl versions and no longer maintained. This PR simply replaces its usage with the actively maintained luaossl library. This does not change the usage of the library at all, only modifies the internal library used.

The [jitsi/luajwt](https://github.com/jitsi/luajwt) repo is still needed by https://github.com/jitsi/jitsi-meet/blob/master/resources/prosody-plugins/token/util.lib.lua which is part of the recommended way of using tokens with JWT.

There seems to be some code in [jitsi/lua-jwt](https://github.com/jitsi/lua-jwt) (notice the hyphen there) that does use luaossl instead of LuaCrypto, however that library is not a drop-in replacement in the prosody-plugins and I have no idea where it is used. Additionally, it has not been updated for 4 years as well.